### PR TITLE
Fixed link to extra page from page 2

### DIFF
--- a/pages/en/2.md
+++ b/pages/en/2.md
@@ -72,7 +72,7 @@ Here are some example sentences that demonstrate this:
 > %info%
 > In addition to "mije" and "meli", some people also use the word "tonsi"
 > to refer to non-binary people, genderqueer people or others who don't fit into 
-> either "man" or "woman". See [extra page 1](x1) for more information.
+> either "man" or "woman". See [extra page 1](en/x1) for more information.
 
 ## Exercises
 


### PR DESCRIPTION
Right now, it just goes to /x1, which is a 404.