### PR TITLE
Update README installation instructions and add Nix-shell option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
 # lipu-sona.pona.la source code
 
-This is the source code to *lipu sona pona*, an educational course for the
-minimalist constructed language *toki pona*.
+This is the source code to _lipu sona pona_, an educational course for the
+minimalist constructed language _toki pona_.
 
 Included are all the files and scripts used to build it.
 
-# automatically building
+## Automatically Building
 
-This website uses *GitHub Pages* to automatically build and deploy the latest
+This website uses _GitHub Pages_ to automatically build and deploy the latest
 version of itself. Whenever new commits are pushed to GitHub's
 `pona-la/lipu-sona` repository, the website uses them to
 build a new version of the website.
 
-# manually building
+## Manually Building
 
 You will need a Linux-based OS, or a UNIX-like environment, to build the
-website from this source package. If you already have one, you can skip until
-the horizontal line, otherwise here is how you can get things working if you
-have Windows or macOS.
+website from this source package. If you already have one, you can continue to
+setup, otherwise open the following section.
+
+<details>
+
+<summary>Setting up on Windows or MacOS</summary>
 
 On Windows 10 and later, you can use
 [WSL](https://learn.microsoft.com/en-us/windows/wsl/) to install a Linux
@@ -33,31 +36,40 @@ If your choice is WSL or VirtualBox, you should also pick a Linux distribution
 ("distro") to run inside of it. [Ubuntu
 Desktop](https://ubuntu.com/download/desktop) is a good choice.
 
----
+</details>
+
+As an alternative on Linux-based systems with Nix installed, you can use the provided nix-shell file to automatically
+build the site. Running the shell automatically runs the makefile and exits once completed.
+
+```bash
+nix-shell
+```
+
+### Prerequisites
 
 After installing one of these, Here are the tools required:
 
- * `discount`, the Markdown-to-HTML converter
- * `cpp`, the C preprocessor that's part of the `gcc` compiler, here used to build stylesheets
- * `make`, the build system used to track which files need to be updated.
+- `discount`, the Markdown-to-HTML converter
+- `cpp`, the C preprocessor that's part of the `gcc` compiler, here used to build stylesheets
+- `make`, the build system used to track which files need to be updated.
 
 Optionally, you might want these tools:
 
- * `git`, to get a copy of this repository's data into your computer and be able
-   to make and commit changes
+- `git`, to get a copy of this repository's data into your computer and be able
+  to make and commit changes
 
 All of these should be available in any Linux distro's (or Homebrew's) package
 manager. Enter the command line provided by your Linux distro, WSL or macOS
 respectively, and use one of these commands:
 
-* Ubuntu / Debian (by themselves or inside WSL): `sudo apt install discount gcc
+- Ubuntu / Debian (by themselves or inside WSL): `sudo apt install discount gcc
 make git`
 
-* Fedora: `sudo yum install discount gcc make git`
+- Fedora: `sudo yum install discount gcc make git`
 
-* Homebrew: `brew install discount gcc make git`
+- Homebrew: `brew install discount gcc make git`
 
----
+### Setup
 
 After doing that, you need to get the repository's data onto your computer. You
 can either "clone" this repository using Git, or download it as an archive and
@@ -82,7 +94,7 @@ If everything goes right, then there should appear a folder called `public`,
 containing all the files ready to be uploaded to a website hosting (such as
 [Neocities](https://neocities.org/)).
 
----
+### Possible Errors
 
 Depending on the environment you're running, this error might appear:
 
@@ -95,8 +107,8 @@ installed in the `discount` package.
 
 Try out the following commands:
 
-* `discount-theme -V`
-* `markdown-theme -V`
+- `discount-theme -V`
+- `markdown-theme -V`
 
 If one of these outputs a version number instead of the `not found` error, then
 edit the `Makefile.cfg` file in a text editor to say the name of the correct
@@ -111,6 +123,3 @@ or
 ```
 THEME=markdown-theme
 ```
-
----
-

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+pkgs.mkShell {
+  buildInputs = [ pkgs.discount ];
+  shellHook = "make -C bin; exit";
+}


### PR DESCRIPTION
Makes the README semantically correct in terms of markdown and adds the option to use a nix-shell shell to build the site.

I made the Windows/MacOS section collapsible for readability as the instruction to "skip to the horizontal line" isn't as nice.

The nix-shell script automatically has git and make installed so it only needs to download discount. The shell is set up to automatically run the correct make command and exit itself.